### PR TITLE
add teardown handling for CLI execution success and failure scenarios

### DIFF
--- a/src/core/ScriptRunner.fs
+++ b/src/core/ScriptRunner.fs
@@ -107,11 +107,18 @@ let runScript options rules =
     // Only cancel the token — do not touch teardown or call exit here.
     // The main thread observes the cancellation via Async.RunSynchronously,
     // exits the build loop cleanly, then runs teardown before exiting.
+    // Double Ctrl+C support: first press cancels gracefully, second press allows OS termination.
+    let mutable cancelledOnce = false
     let handler =
         new System.ConsoleCancelEventHandler(fun _ args ->
-            args.Cancel <- true  // suppress default process termination
-            logger.Log Error "Build interrupted by user"
-            cts.Cancel())
+            if not cancelledOnce then
+                args.Cancel <- true  // suppress default process termination
+                cancelledOnce <- true
+                logger.Log Error "Build interrupted by user. Press Ctrl+C again to force exit"
+                cts.Cancel()
+            else
+                args.Cancel <- false  // allow default termination on second press
+                logger.Log Error "Force exiting build process...")
     System.Console.CancelKeyPress.AddHandler(handler)
 
     logger.Log Level.Debug "Options: %A" { options with Vars = [] }

--- a/src/core/ScriptRunner.fs
+++ b/src/core/ScriptRunner.fs
@@ -107,11 +107,12 @@ let runScript options rules =
     // Only cancel the token — do not touch teardown or call exit here.
     // The main thread observes the cancellation via Async.RunSynchronously,
     // exits the build loop cleanly, then runs teardown before exiting.
-    System.Console.CancelKeyPress
-    |> Event.add (fun args ->
-        args.Cancel <- true  // suppress default process termination
-        logger.Log Error "Build interrupted by user"
-        cts.Cancel())
+    let handler =
+        new System.ConsoleCancelEventHandler(fun _ args ->
+            args.Cancel <- true  // suppress default process termination
+            logger.Log Error "Build interrupted by user"
+            cts.Cancel())
+    System.Console.CancelKeyPress.AddHandler(handler)
 
     logger.Log Level.Debug "Options: %A" { options with Vars = [] }
         // be careful with debug option as it may contain sensitive info like script variables
@@ -175,5 +176,7 @@ let runScript options rules =
             | Some exn -> raise exn
             | None -> ()
     finally
+        System.Console.CancelKeyPress.RemoveHandler(handler)
+        cts.Dispose()
         finalize()
     if exitCode <> 0 then exit exitCode

--- a/src/core/ScriptRunner.fs
+++ b/src/core/ScriptRunner.fs
@@ -157,11 +157,12 @@ let runScript options rules =
                 ctx |> runTeardownAsync |> Async.RunSynchronously
             with teardownExn ->
                 ctx.Logger.Log Error "Teardown failed: %s" teardownExn.Message
+                ctx.Logger.Log Verbose "Teardown error details are:\n%A\n\n" teardownExn
                 if exitCode = 0 then
                     // build succeeded but teardown failed — teardown is the only failure
                     exitCode <- 2
                     if options.ThrowOnError then
-                        reraisedError <- Some teardownExn
+                        reraisedError <- Some (XakeException "Teardown failure. See log file for details.")
                 // else: build already failed — log teardown failure but preserve the
                 // original build error in reraisedError and exitCode so it is reported
 

--- a/src/core/ScriptRunner.fs
+++ b/src/core/ScriptRunner.fs
@@ -33,6 +33,12 @@ let createScriptContext (opts: ExecOptions) rules =
             Storage.openDb dbPath engineOpts.Logger
     ExecCore.createContextCore engineOpts db opts.Vars opts.Progress
 
+let runTeardownAsync (ctx: ExecContext) =
+    async {
+        for targetName in ctx.Engine.Options.Teardown do
+            do! ExecCore.demandTarget ctx targetName |> Async.Ignore
+    }
+
 /// Performs a dry run: analyzes dependencies and logs what would be rebuilt without executing anything.
 /// Displays estimated build time and parallelism degree.
 let dryRun (ctx: ExecContext) (groups: string list list) =
@@ -125,6 +131,7 @@ let runScript options rules =
             targetLists |> dryRun ctx
         | _ ->
             let start = System.DateTime.Now
+            let mutable reraisedError = None
             try
                 targetLists |> ExecCore.runBuild ctx |> Async.RunSynchronously |> ignore
                 ctx.Logger.Log Message "\n\n    Build completed in %A\n" (System.DateTime.Now - start)
@@ -139,8 +146,14 @@ let runScript options rules =
                 do ctx.Logger.Log Message "\n\n\tBuild failed after running for %A\n" (System.DateTime.Now - start)
 
                 if options.ThrowOnError then
-                    raise (XakeException "Script failure. See log file for details.")
+                    reraisedError <- Some (XakeException "Script failure. See log file for details.")
                 exitCode <- 2
+
+            ctx |> runTeardownAsync |> Async.RunSynchronously
+
+            match reraisedError with
+            | Some exn -> raise exn
+            | None -> ()
     finally
         finalize()
     if exitCode <> 0 then exit exitCode

--- a/src/core/ScriptRunner.fs
+++ b/src/core/ScriptRunner.fs
@@ -102,16 +102,16 @@ let dryRun (ctx: ExecContext) (groups: string list list) =
 let runScript options rules =
     let ctx, finalize = createScriptContext options rules
     let logger = ctx.Logger
+    let cts = new System.Threading.CancellationTokenSource()
 
+    // Only cancel the token — do not touch teardown or call exit here.
+    // The main thread observes the cancellation via Async.RunSynchronously,
+    // exits the build loop cleanly, then runs teardown before exiting.
     System.Console.CancelKeyPress
-    |> Event.add (fun _ ->
+    |> Event.add (fun args ->
+        args.Cancel <- true  // suppress default process termination
         logger.Log Error "Build interrupted by user"
-        try
-            ctx |> runTeardownAsync |> Async.RunSynchronously
-        with exn ->
-            logger.Log Error "Teardown failed during cancellation: %s" exn.Message
-        finalize()
-        exit 1)
+        cts.Cancel())
 
     logger.Log Level.Debug "Options: %A" { options with Vars = [] }
         // be careful with debug option as it may contain sensitive info like script variables
@@ -137,9 +137,14 @@ let runScript options rules =
             let start = System.DateTime.Now
             let mutable reraisedError = None
             try
-                targetLists |> ExecCore.runBuild ctx |> Async.RunSynchronously |> ignore
+                targetLists |> ExecCore.runBuild ctx |> fun a -> Async.RunSynchronously(a, cancellationToken = cts.Token) |> ignore
                 ctx.Logger.Log Message "\n\n    Build completed in %A\n" (System.DateTime.Now - start)
-            with | exn ->
+            with
+            | :? System.OperationCanceledException ->
+                // Ctrl+C: build async workflow was cancelled; fall through to teardown on main thread
+                ctx.Logger.Log Message "\n\n\tBuild interrupted after running for %A\n" (System.DateTime.Now - start)
+                exitCode <- 1
+            | exn ->
                 let exceptions = exn |> ExecCore.unwindAggEx
                 let errors = exceptions |> Seq.map (fun e -> e.Message) in
                 let details = exceptions |> Seq.last |> fun e -> e.ToString()
@@ -150,7 +155,7 @@ let runScript options rules =
                 do ctx.Logger.Log Message "\n\n\tBuild failed after running for %A\n" (System.DateTime.Now - start)
 
                 if options.ThrowOnError then
-                    reraisedError <- Some (XakeException "Script failure. See log file for details.")
+                    reraisedError <- Some (XakeException errorText)
                 exitCode <- 2
 
             try
@@ -162,7 +167,7 @@ let runScript options rules =
                     // build succeeded but teardown failed — teardown is the only failure
                     exitCode <- 2
                     if options.ThrowOnError then
-                        reraisedError <- Some (XakeException "Teardown failure. See log file for details.")
+                        reraisedError <- Some (XakeException (sprintf "Teardown failure: %s" teardownExn.Message))
                 // else: build already failed — log teardown failure but preserve the
                 // original build error in reraisedError and exitCode so it is reported
 

--- a/src/core/ScriptRunner.fs
+++ b/src/core/ScriptRunner.fs
@@ -106,6 +106,10 @@ let runScript options rules =
     System.Console.CancelKeyPress
     |> Event.add (fun _ ->
         logger.Log Error "Build interrupted by user"
+        try
+            ctx |> runTeardownAsync |> Async.RunSynchronously
+        with exn ->
+            logger.Log Error "Teardown failed during cancellation: %s" exn.Message
         finalize()
         exit 1)
 
@@ -149,7 +153,17 @@ let runScript options rules =
                     reraisedError <- Some (XakeException "Script failure. See log file for details.")
                 exitCode <- 2
 
-            ctx |> runTeardownAsync |> Async.RunSynchronously
+            try
+                ctx |> runTeardownAsync |> Async.RunSynchronously
+            with teardownExn ->
+                ctx.Logger.Log Error "Teardown failed: %s" teardownExn.Message
+                if exitCode = 0 then
+                    // build succeeded but teardown failed — teardown is the only failure
+                    exitCode <- 2
+                    if options.ThrowOnError then
+                        reraisedError <- Some teardownExn
+                // else: build already failed — log teardown failure but preserve the
+                // original build error in reraisedError and exitCode so it is reported
 
             match reraisedError with
             | Some exn -> raise exn

--- a/src/core/XakeScriptBuilder.fs
+++ b/src/core/XakeScriptBuilder.fs
@@ -172,9 +172,7 @@ module XakeScriptBuilder =
                 try
                     let snapshot = inFlight.Values |> Seq.map (fun l -> l.Value) |> Seq.toArray
                     do! snapshot |> Array.map Async.AwaitTask |> Async.Parallel |> Async.Ignore
-                    for name in engine.Options.Teardown do
-                        let ctx = makeCtx None
-                        do! ExecCore.demandTarget ctx name |> Async.Ignore
+                    do! makeCtx None |> ScriptRunner.runTeardownAsync
                 finally
                     finalize ()
             } |> Async.StartAsTask :> Task

--- a/src/tests/CommandLineTests.fs
+++ b/src/tests/CommandLineTests.fs
@@ -290,6 +290,3 @@ let ``original build error is preserved when teardown also fails``() =
 
         Assert.AreEqual(["build"; "cleanup"], log |> Seq.toList)
         Assert.That(exn.Message, Does.Contain "build boom")
-
-        // Assert.AreEqual("build boom", exn.Message)
-   

--- a/src/tests/CommandLineTests.fs
+++ b/src/tests/CommandLineTests.fs
@@ -243,3 +243,53 @@ let ``skips teardown for dryrun and dump CLI modes``() =
         }
 
         Assert.IsEmpty(log)
+
+[<Test>]
+let ``teardown failure is reported when build succeeds``() =
+    withTempRoot "cli-teardown-fail-after-success" <| fun testRoot ->
+        let log = System.Collections.Generic.List<string> ()
+
+        let exn =
+            Assert.Throws<XakeException>(fun () ->
+                xakeArgs ["build"] { XakeOptions with ProjectRoot = testRoot; NoPersist = true; Nologo = true; ThrowOnError = true } {
+                    teardown ["cleanup"]
+                    rules [
+                        "build" => recipe {
+                            lock log <| fun () -> log.Add "build"
+                        }
+                        "cleanup" => recipe {
+                            lock log <| fun () -> log.Add "cleanup"
+                            failwith "teardown boom"
+                        }
+                    ]
+                })
+
+        Assert.AreEqual(["build"; "cleanup"], log |> Seq.toList)
+        Assert.That(exn.Message, Does.Contain("Teardown failure"))
+
+[<Test>]
+let ``original build error is preserved when teardown also fails``() =
+    withTempRoot "cli-teardown-both-fail" <| fun testRoot ->
+        let log = System.Collections.Generic.List<string> ()
+
+        let exn =
+            Assert.Throws<XakeException>(fun () ->
+                xakeArgs ["build"] { XakeOptions with ProjectRoot = testRoot; NoPersist = true; Nologo = true; ThrowOnError = true } {
+                    teardown ["cleanup"]
+                    rules [
+                        "build" => recipe {
+                            lock log <| fun () -> log.Add "build"
+                            failwith "build boom"
+                        }
+                        "cleanup" => recipe {
+                            lock log <| fun () -> log.Add "cleanup"
+                            failwith "teardown boom"
+                        }
+                    ]
+                })
+
+        Assert.AreEqual(["build"; "cleanup"], log |> Seq.toList)
+        Assert.That(exn.Message, Does.Contain "build boom")
+
+        // Assert.AreEqual("build boom", exn.Message)
+   

--- a/src/tests/CommandLineTests.fs
+++ b/src/tests/CommandLineTests.fs
@@ -13,6 +13,16 @@ let XakeOptions = ExecOptions.Default
 let private parseArgs args initial =
     args |> List.fold ParseArgs.foldFunction (initial, ParseArgs.TopLevel) |> fst
 
+let private withTempRoot testName action =
+    let testRoot = currentDir </> "~testout~" </> (testName + "-" + System.Guid.NewGuid().ToString "N")
+    Directory.CreateDirectory testRoot |> ignore
+    try
+        action testRoot
+    finally
+        try
+            Directory.Delete(testRoot, true)
+        with _ -> ()
+
 [<Test>]
 let ``accepts various switches``() =
 
@@ -161,3 +171,75 @@ let ``resetdb ignores previously recorded information``() =
         try
             Directory.Delete(testRoot, true)
         with _ -> ()
+
+[<Test>]
+let ``runs teardown after successful CLI execution``() =
+    withTempRoot "cli-teardown-success" <| fun testRoot ->
+        let log = System.Collections.Generic.List<string> ()
+
+        xakeArgs ["build"] { XakeOptions with ProjectRoot = testRoot; DbFileName = ".xake-teardown-success"; NoPersist = true; Nologo = true } {
+            teardown ["cleanup"]
+            rules [
+                "build" => recipe {
+                    lock log <| fun () -> log.Add "build"
+                }
+                "cleanup" => recipe {
+                    lock log <| fun () -> log.Add "cleanup"
+                }
+            ]
+        }
+
+        Assert.AreEqual(["build"; "cleanup"], log |> Seq.toList)
+
+[<Test>]
+let ``runs teardown after failed CLI execution when ThrowOnError is enabled``() =
+    withTempRoot "cli-teardown-failure" <| fun testRoot ->
+        let log = System.Collections.Generic.List<string> ()
+
+        Assert.Throws<XakeException>(fun () ->
+            xakeArgs ["build"] { XakeOptions with ProjectRoot = testRoot; DbFileName = ".xake-teardown-failure"; NoPersist = true; Nologo = true; ThrowOnError = true } {
+                teardown ["cleanup"]
+                rules [
+                    "build" => recipe {
+                        lock log <| fun () -> log.Add "build"
+                        failwith "boom"
+                    }
+                    "cleanup" => recipe {
+                        lock log <| fun () -> log.Add "cleanup"
+                    }
+                ]
+            }) |> ignore
+
+        Assert.AreEqual(["build"; "cleanup"], log |> Seq.toList)
+
+[<Test>]
+let ``skips teardown for dryrun and dump CLI modes``() =
+    withTempRoot "cli-teardown-nonrun" <| fun testRoot ->
+        let log = System.Collections.Generic.List<string> ()
+        let options = { XakeOptions with ProjectRoot = testRoot; DbFileName = ".xake-teardown-nonrun"; NoPersist = true; Nologo = true }
+
+        xakeArgs ["--dryrun"; "build"] options {
+            teardown ["cleanup"]
+            rules [
+                "build" => recipe {
+                    lock log <| fun () -> log.Add "build"
+                }
+                "cleanup" => recipe {
+                    lock log <| fun () -> log.Add "cleanup"
+                }
+            ]
+        }
+
+        xakeArgs ["--dump"; "build"] options {
+            teardown ["cleanup"]
+            rules [
+                "build" => recipe {
+                    lock log <| fun () -> log.Add "build"
+                }
+                "cleanup" => recipe {
+                    lock log <| fun () -> log.Add "cleanup"
+                }
+            ]
+        }
+
+        Assert.IsEmpty(log)


### PR DESCRIPTION
Adds consistent teardown execution for CLI script runs so teardown targets run after both successful builds and build failures (including when ThrowOnError is enabled), aligning CLI behavior with the long-lived engine teardown flow.

**Changes:**

Introduces ScriptRunner.runTeardownAsync and uses it from both CLI execution and XakeEngine.StopAsync.
Updates CLI runScript to always run teardown after build completion/failure, and to preserve the original build error when teardown also fails.
Adds CLI-focused tests covering teardown on success, failure, teardown-failure reporting, and skipping teardown for --dryrun/--dump.